### PR TITLE
Fix weapons/slug/claws.json

### DIFF
--- a/animations/weapons/slug/claws.json
+++ b/animations/weapons/slug/claws.json
@@ -2,6 +2,9 @@
 	"item:slug:claw": "item:slug:claws",
 	"item:slug:claws": [
 		{
+			"overrides": [
+				"item:group:brawling"
+			],
 			"trigger": "attack-roll",
 			"preset": "onToken",
 			"file": "jb2a.claws.400px.red",


### PR DESCRIPTION
Prevent double-animation when claws are also in the brawling group (occurs for some ancestries)