### PR TITLE
Adding druidic order base focus spells and some other spells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to [Semantic Versioning](<https://semver.org/spec/v2.0.
 
 ## [Unreleased]
 
+### Added
+
+- Dueling Dance, Dueling Parry, Twin Parry & Twin Defense now share the Raise a Shield animation
+
+- **New Animations**
+  - Cornucopia, Crushing Ground, Guidance, Heal Animal, Lose the Path, Mushroom Patch, Needle Darts, Tempest Surge, Wildfire, Darkvision, Grease, Harmonize Self, Revealing Light, See the Unseen, Combustion, Holy Light, Magnetic Acceleration, Vision of Death, Howling Blizzard, Disintegrate, Spirit Blast. ([@Aziareel](<https://github.com/Aziareel>))
+
+### Fixed
+
+- Vitality Lash should now work again
+
 ## [0.9.1] - 2024-09-12
 
 ### Changed

--- a/animations/effects/dueling-dance.json
+++ b/animations/effects/dueling-dance.json
@@ -1,0 +1,3 @@
+{
+	"effect:dueling-dance": "effect:raise-a-shield"
+}

--- a/animations/effects/dueling-parry.json
+++ b/animations/effects/dueling-parry.json
@@ -1,0 +1,3 @@
+{
+	"effect:dueling-parry": "effect:raise-a-shield"
+}

--- a/animations/effects/twin-parry.json
+++ b/animations/effects/twin-parry.json
@@ -1,0 +1,4 @@
+{
+	"effect:twin-parry": "effect:raise-a-shield",
+	"effect:twin-parry-parry-trait": "effect:raise-a-shield"
+}

--- a/animations/effects/twinned-defense.json
+++ b/animations/effects/twinned-defense.json
@@ -1,0 +1,3 @@
+{
+	"effect:twinned-defense": "effect:raise-a-shield"
+}

--- a/animations/spells/1st/cornucopia.json
+++ b/animations/spells/1st/cornucopia.json
@@ -1,0 +1,16 @@
+{
+	"spell:cornucopia": [
+		{
+			"trigger": "action",
+			"preset": "onToken",
+			"file": "jb2a.plant_growth.03.round.2x2.complete.greenyellow",
+			"options": {
+				"scaleToObject": 2,
+				"duration": 2500,
+				"sound": {
+					"file": "graphics-sfx.magic.nature.growth.01"
+				}
+			}
+		}
+	]
+}

--- a/animations/spells/1st/crushing-ground.json
+++ b/animations/spells/1st/crushing-ground.json
@@ -1,0 +1,17 @@
+{
+	"item:slug:crushing-ground": [
+		{
+			"trigger": "damage-roll",
+			"preset": "onToken",
+			"file": "jb2a.impact.ground_crack.02.orange",
+			"options": {
+				"preset": {
+					"location": "target"
+				},
+				"scaleToObject": {
+					"value": 1.5
+				}
+			}
+		}
+	]
+}

--- a/animations/spells/1st/guidance.json
+++ b/animations/spells/1st/guidance.json
@@ -1,0 +1,12 @@
+{
+	"effect:guidance": [
+		{
+			"trigger": "effect",
+			"preset": "onToken",
+			"file": "jb2a.bless.400px.intro.yellow",
+			"options": {
+				"scaleToObject": 1.5
+			}
+		}
+	]
+}

--- a/animations/spells/1st/heal-animal.json
+++ b/animations/spells/1st/heal-animal.json
@@ -1,0 +1,3 @@
+{
+	"item:slug:heal-animal": "item:slug:heal"
+}

--- a/animations/spells/1st/lose-the-path.json
+++ b/animations/spells/1st/lose-the-path.json
@@ -1,0 +1,31 @@
+{
+	"item:slug:lose-the-path": [
+		{
+			"trigger": "saving-throw",
+			"preset": "onToken",
+			"options": {
+				"preset": {
+					"location": "target"
+				},
+				"scaleToObject": 1.5,
+				"duration": 3000,
+				"fadeIn": 250,
+				"fadeOut": 500
+			},
+			"contents": [
+				{
+					"predicate": [
+						"jb2a:free"
+					],
+					"file": "jb2a.magic_signs.rune.illusion.complete.purple"
+				},
+				{
+					"predicate": [
+						"jb2a:patreon"
+					],
+					"file": "jb2a.magic_signs.rune.illusion.complete.green"
+				}
+			]
+		}
+	]
+}

--- a/animations/spells/1st/mushroom-patch.json
+++ b/animations/spells/1st/mushroom-patch.json
@@ -1,0 +1,36 @@
+{
+	"origin:item:slug:mushroom-patch": [
+		{
+			"trigger": "place-template",
+			"preset": "template",
+			"file": "jb2a.plant_growth.03.round.4x4.complete.greenyellow",
+			"options": {
+				"scaleToObject": 1.1
+			},
+			"contents": [
+				{
+					"predicate": [
+						{
+							"gte": [
+								"settings:quality",
+								1
+							]
+						}
+					]
+				},
+				{
+					"predicate": [
+						"settings:persistent"
+					],
+					"options": {
+						"persist": {
+							"value": true,
+							"persistTokenPrototype": true
+						},
+						"tieToDocuments": true
+					}
+				}
+			]
+		}
+	]
+}

--- a/animations/spells/1st/needle-darts.json
+++ b/animations/spells/1st/needle-darts.json
@@ -1,0 +1,34 @@
+{
+	"item:slug:needle-darts": [
+		{
+			"trigger": "attack-roll",
+			"preset": "ranged",
+			"options": {
+				"repeats": {
+					"count": 2,
+					"delayMin": 100,
+					"delayMax": 200
+				},
+				"preset": {
+					"stretchTo": {
+						"randomOffset": 0.5
+					}
+				}
+			},
+			"contents": [
+				{
+					"predicate": [
+						"jb2a:free"
+					],
+					"file": "jb2a.bolt.physical.orange"
+				},
+				{
+					"predicate": [
+						"jb2a:patreon"
+					],
+					"file": "jb2a.bolt.physical.white"
+				}
+			]
+		}
+	]
+}

--- a/animations/spells/1st/tempest-surge.json
+++ b/animations/spells/1st/tempest-surge.json
@@ -1,0 +1,15 @@
+{
+	"item:slug:tempest-surge": [
+		{
+			"trigger": "damage-roll",
+			"preset": "onToken",
+			"file": "jb2a.lightning_orb.01.loop.bluepurple.0",
+			"options": {
+				"preset": {
+					"location": "target"
+				},
+				"scaleToObject": 2
+			}
+		}
+	]
+}

--- a/animations/spells/1st/vitality-lash.json
+++ b/animations/spells/1st/vitality-lash.json
@@ -1,9 +1,14 @@
 {
 	"item:slug:vitality-lash": [
 		{
-			"trigger": "saving-throw",
+			"trigger": "damage-roll",
 			"preset": "ranged",
-			"presets": [
+			"options": {
+				"sound": {
+					"file": "graphics-sfx.magic.arcane.cast.02"
+				}
+			},
+			"contents": [
 				{
 					"predicate": [
 						"jb2a:free"

--- a/animations/spells/1st/wildfire.json
+++ b/animations/spells/1st/wildfire.json
@@ -1,0 +1,36 @@
+{
+	"origin:item:slug:wildfire": [
+		{
+			"trigger": "place-template",
+			"preset": "template",
+			"file": "jb2a.ground_cracks.orange.02",
+			"options": {
+				"scaleToObject": 1.1
+			},
+			"contents": [
+				{
+					"predicate": [
+						{
+							"gte": [
+								"settings:quality",
+								1
+							]
+						}
+					]
+				},
+				{
+					"predicate": [
+						"settings:persistent"
+					],
+					"options": {
+						"persist": {
+							"value": true,
+							"persistTokenPrototype": true
+						},
+						"tieToDocuments": true
+					}
+				}
+			]
+		}
+	]
+}

--- a/animations/spells/2nd/darkvision.json
+++ b/animations/spells/2nd/darkvision.json
@@ -1,0 +1,4 @@
+{
+	"effect:darkvision": "effect:see-the-unseen",
+	"effect:darkvision-24-hours": "effect:darkvision"
+}

--- a/animations/spells/2nd/grease.json
+++ b/animations/spells/2nd/grease.json
@@ -1,0 +1,18 @@
+{
+	"item:slug:grease": [
+		{
+			"trigger": "saving-throw",
+			"preset": "onToken",
+			"file": "jb2a.grease.dark_brown.loop",
+			"options": {
+				"preset": {
+					"location": "target"
+				},
+				"duration": 3000,
+				"scaleToObject": 1.1,
+				"fadeIn": 250,
+				"fadeOut": 500
+			}
+		}
+	]
+}

--- a/animations/spells/2nd/harmonize-self.json
+++ b/animations/spells/2nd/harmonize-self.json
@@ -1,0 +1,12 @@
+{
+	"item:slug:harmonize-self": [
+		{
+			"trigger": "damage-taken",
+			"preset": "onToken",
+			"file": "jb2a.energy_strands.in.green.01.2",
+			"options": {
+				"scaleToObject": 2
+			}
+		}
+	]
+}

--- a/animations/spells/2nd/revealing-light.json
+++ b/animations/spells/2nd/revealing-light.json
@@ -1,0 +1,36 @@
+{
+	"origin:item:slug:revealing-light": [
+		{
+			"trigger": "place-template",
+			"preset": "template",
+			"file": "jb2a.markers.circle_of_stars.blue",
+			"options": {
+				"scaleToObject": 1.1
+			},
+			"contents": [
+				{
+					"predicate": [
+						{
+							"gte": [
+								"settings:quality",
+								1
+							]
+						}
+					]
+				},
+				{
+					"predicate": [
+						"settings:persistent"
+					],
+					"options": {
+						"persist": {
+							"value": true,
+							"persistTokenPrototype": true
+						},
+						"tieToDocuments": true
+					}
+				}
+			]
+		}
+	]
+}

--- a/animations/spells/2nd/see-the-unseen.json
+++ b/animations/spells/2nd/see-the-unseen.json
@@ -1,0 +1,12 @@
+{
+	"effect:see-the-unseen": [
+		{
+			"preset": "onToken",
+			"trigger": "effect",
+			"file": "jb2a.magic_signs.rune.illusion.intro.purple",
+			"options": {
+				"scaleToObject": 1.5
+			}
+		}
+	]
+}

--- a/animations/spells/3rd/combustion.json
+++ b/animations/spells/3rd/combustion.json
@@ -1,0 +1,24 @@
+{
+	"item:slug:combustion": [
+		{
+			"trigger": "damage-roll",
+			"preset": "onToken",
+			"file": "jb2a.campfire.03.02.loop.orange",
+			"options": {
+				"preset": {
+					"location": "target",
+					"atLocation": {
+						"offset": {
+							"y": -2.1
+						},
+						"gridUnits": true
+					}
+				},
+				"scaleToObject": {
+					"value": 7,
+					"considerTokenScale": true
+				}
+			}
+		}
+	]
+}

--- a/animations/spells/3rd/holy-light.json
+++ b/animations/spells/3rd/holy-light.json
@@ -1,0 +1,22 @@
+{
+	"item:slug:holy-light": [
+		{
+			"trigger": "attack-roll",
+			"preset": "ranged",
+			"contents": [
+				{
+					"predicate": [
+						"jb2a:free"
+					],
+					"file": "jb2a.guiding_bolt.01.blueyellow"
+				},
+				{
+					"predicate": [
+						"jb2a:patreon"
+					],
+					"file": "jb2a.eldritch_blast.rainbow"
+				}
+			]
+		}
+	]
+}

--- a/animations/spells/3rd/magnetic-acceleration.json
+++ b/animations/spells/3rd/magnetic-acceleration.json
@@ -1,0 +1,9 @@
+{
+	"item:slug:magnetic-acceleration": [
+		{
+			"trigger": "attack-roll",
+			"preset": "ranged",
+			"file": "jb2a.ranged.02.instant.01.yellow"
+		}
+	]
+}

--- a/animations/spells/4th/vision-of-death.json
+++ b/animations/spells/4th/vision-of-death.json
@@ -1,0 +1,27 @@
+{
+	"item:slug:vision-of-death": [
+		{
+			"trigger": "damage-roll",
+			"preset": "onToken",
+			"options": {
+				"preset": {
+					"location": "target"
+				}
+			},
+			"contents": [
+				{
+					"predicate": [
+						"jb2a:free"
+					],
+					"file": "jb2a.toll_the_dead.green.skull_smoke"
+				},
+				{
+					"predicate": [
+						"jb2a:patreon"
+					],
+					"file": "jb2a.toll_the_dead.purple.skull_smoke"
+				}
+			]
+		}
+	]
+}

--- a/animations/spells/5th/howling-blizzard.json
+++ b/animations/spells/5th/howling-blizzard.json
@@ -1,0 +1,74 @@
+{
+	"origin:item:slug:howling-blizzard": [
+		{
+			"trigger": "place-template",
+			"preset": "template",
+			"file": "jb2a.cone_of_cold.blue",
+			"predicate": [
+				"origin:item:area:type:cone"
+			],
+			"contents": [
+				{
+					"predicate": [
+						{
+							"gte": [
+								"settings:quality",
+								1
+							]
+						}
+					]
+				},
+				{
+					"predicate": [
+						{
+							"gte": [
+								"settings:quality",
+								2
+							]
+						}
+					],
+					"options": {
+						"rotate": -30
+					}
+				},
+				{
+					"predicate": [
+						{
+							"gte": [
+								"settings:quality",
+								2
+							]
+						}
+					],
+					"options": {
+						"rotate": 30
+					}
+				}
+			]
+		},
+		{
+			"trigger": "place-template",
+			"preset": "template",
+			"file": "jb2a.sleet_storm.blue",
+			"predicate": [
+				"origin:item:area:type:burst"
+			],
+			"options": {
+				"scaleToObject": 1
+			}
+		}
+	],
+	"item:slug:howling-blizzard": [
+		{
+			"trigger": "damage-taken",
+			"preset": "onToken",
+			"file": "jb2a.impact.ground_crack.frost.01.white",
+			"options": {
+				"preset": {
+					"location": "target"
+				},
+				"scaleToObject": 1.5
+			}
+		}
+	]
+}

--- a/animations/spells/5th/synesthesia.json
+++ b/animations/spells/5th/synesthesia.json
@@ -1,0 +1,17 @@
+{
+	"item:slug:synesthesia": [
+		{
+			"trigger": "saving-throw",
+			"preset": "onToken",
+			"file": "jb2a.particles.swirl.greenyellow.01.01",
+			"options": {
+				"preset": {
+					"location": "target"
+				},
+				"scaleToObject": 2,
+				"fadeIn": 250,
+				"fadeOut": 500
+			}
+		}
+	]
+}

--- a/animations/spells/6th/disintegrate.json
+++ b/animations/spells/6th/disintegrate.json
@@ -1,0 +1,33 @@
+{
+	"item:slug:disintegrate": [
+		{
+			"trigger": "attack-roll",
+			"preset": "ranged",
+			"options": {
+				"sound": {
+					"file": "graphics-sfx.magic.lightning.bolt.impact"
+				},
+				"filter": {
+					"type": "ColorMatrix",
+					"options": {
+						"hue": -110
+					}
+				}
+			},
+			"contents": [
+				{
+					"predicate": [
+						"jb2a:free"
+					],
+					"file": "jb2a.disintegrate.green"
+				},
+				{
+					"predicate": [
+						"jb2a:patreon"
+					],
+					"file": "jb2a.disintegrate.dark_red"
+				}
+			]
+		}
+	]
+}

--- a/animations/spells/6th/spirit-blast.json
+++ b/animations/spells/6th/spirit-blast.json
@@ -1,0 +1,9 @@
+{
+	"item:slug:spirit-blast": [
+		{
+			"trigger": "damage-roll",
+			"preset": "ranged",
+			"file": "jb2a.ranged.03.instant.01.bluegreen"
+		}
+	]
+}


### PR DESCRIPTION
Gave the Raise a Shield effect to similar effects:
- Dueling Dance
- Dueling Parry
- Twin Parry
- Twinned Defense

Added some druidic order focus spells as well as additional spells:
- 1st rank:
  - Cornucopia
  - Crushing Ground
  - Guidance
  - Heal Animal
  - Lose the Path
  - Mushroom Patch
  - Needle Darts
  - Tempest Surge
  - Vitality Lash (Fixed, trigger set on damage-roll like Void Warp)
  - Wildfire
 - 2nd rank:
   - Darkvision
   - Grease
   - Harmonize Self
   - Revealing Light
   - See the Unseen
 - 3rd rank:
  - Combustion
  - Holy Light
  - Magnetic Acceleration
 - 4th rank:
   - Vision of Death
 - 5th rank:
   - Howling Blizzard
   - Synesthesia
- 6th rank:
  - Disintegrate
  - Spirit Blast

For the druidic order spells I skipped Rising Surf, as we would require a trigger to recognize movement. Or at least a way to target a location on screen.

I noticed that you can create dependencies, e.g. Darkvision using the same animations as See the Unseen. 
I wonder if you can create such a dependancy and than modify some changes on top of that. For example, Void Warp and Vitality Lash are basically the same spell with a different color for the animation.
  