### PR TITLE
[Animations] Adding new spells, effects and actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](<https://semver.org/spec/v2.0.
   - Champion's Resistence, Devise a Stratagem, Strategic Strike, Surgical Shock, Cyclonic Ascent, Sneak Attack, Exploit Vulnerability (using  PF2e Exploit Vulnerability), Healer's Gloves (@Aziareel)
   - Dueling Dance, Dueling Parry, Twin Parry & Twin Defense now share the Raise a Shield animation. (@Aziareel)
   - Cornucopia, Crushing Ground, Guidance, Heal Animal, Lose the Path, Mushroom Patch, Needle Darts, Tempest Surge, Wildfire, Darkvision, Grease, Harmonize Self, Revealing Light, See the Unseen, Combustion, Holy Light, Magnetic Acceleration, Vision of Death, Howling Blizzard (+ Oscillating Wave), Disintegrate, Spirit Blast. (@Aziareel)
-  - Faerie Dust, Figment, Imaginary Weapon, Lay on Hands, Blazing Bolt, Blood Vendetta, Bloodspray Curse, Cleanse Affliction, Clear Mind, Sound Body, Darkness, False Vitality, Floating Flame, Heat Metal (+ Oscillating Wave), Paranoia, Translate, Water Breathing, Worm's Repast, Earthbind, Heroism, Cinder Swarm, Ymeri'S Mark, Breath of Life, Flammable Fumes, Toxic Cloud, Flame Vortex (+ Oscillating Wave)
+  - Faerie Dust, Figment, Imaginary Weapon, Lay on Hands, Blazing Bolt, Blood Vendetta, Bloodspray Curse, Cleanse Affliction, Clear Mind, Sound Body, Darkness, False Vitality, Floating Flame, Heat Metal (+ Oscillating Wave), Paranoia, Powerful Inhalation, Translate, Water Breathing, Worm's Repast, Earthbind, Heroism, Cinder Swarm, Ymeri'S Mark, Breath of Life, Flammable Fumes, Toxic Cloud, Flame Vortex (+ Oscillating Wave)
   - Persistent Damage (On Apply Damage Effects Only) (@ChasarooniZ)
   - Creature Abilities; Urevian - Diabolic Quill (@ChasarooniZ)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ and this project adheres to [Semantic Versioning](<https://semver.org/spec/v2.0.
 
 - Polish translation (thank you @Lioheart!)
 - **New Animations**
-  - Treat Wounds/Battle Medicine, Dirty Trick, Grapple, Trip. (@Aziareel)
-  - Champion's Resistence, Devise a Stratagem, Strategic Strike, Surgical Shock, Cyclonic Ascent, Sneak Attack, Exploit Vulnerability (using  PF2e Exploit Vulnerability), Healer's Gloves (@Aziareel)
+  - Treat Wounds/Battle Medicine (using Workbench), Dirty Trick, Grapple, Trip. (@Aziareel)
+  - Champion's Resistence, Devise a Stratagem, Strategic Strike, Surgical Shock, Cyclonic Ascent, Sneak Attack, Exploit Vulnerability (using  PF2e Exploit Vulnerability Module), Healer's Gloves (@Aziareel)
   - Dueling Dance, Dueling Parry, Twin Parry & Twin Defense now share the Raise a Shield animation. (@Aziareel)
   - Cornucopia, Crushing Ground, Guidance, Heal Animal, Lose the Path, Mushroom Patch, Needle Darts, Tempest Surge, Wildfire, Darkvision, Grease, Harmonize Self, Revealing Light, See the Unseen, Combustion, Holy Light, Magnetic Acceleration, Vision of Death, Howling Blizzard (+ Oscillating Wave), Disintegrate, Spirit Blast. (@Aziareel)
   - Faerie Dust, Figment, Imaginary Weapon, Lay on Hands, Blazing Bolt, Blood Vendetta, Bloodspray Curse, Cleanse Affliction, Clear Mind, Sound Body, Darkness, False Vitality, Floating Flame, Heat Metal (+ Oscillating Wave), Paranoia, Powerful Inhalation, Translate, Water Breathing, Worm's Repast, Earthbind, Heroism, Cinder Swarm, Ymeri'S Mark, Breath of Life, Flammable Fumes, Toxic Cloud, Flame Vortex (+ Oscillating Wave)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,20 @@ and this project adheres to [Semantic Versioning](<https://semver.org/spec/v2.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Spear Group Attacks now work with JB2A Free version
+- Oscillating Wave's Breath Fire/Fireball now have an additional animation
+
 ### Added
 
 - Polish translation (thank you @Lioheart!)
 - **New Animations**
   - Treat Wounds/Battle Medicine, Dirty Trick, Grapple, Trip. (@Aziareel)
-  - Champion's Resistence, Devise a Stratagem, Strategic Strike, Surgical Shock, Cyclonic Ascent, Sneak Attack, Exploit Vulnerability (using  PF2e Exploit Vulnerability)
+  - Champion's Resistence, Devise a Stratagem, Strategic Strike, Surgical Shock, Cyclonic Ascent, Sneak Attack, Exploit Vulnerability (using  PF2e Exploit Vulnerability), Healer's Gloves (@Aziareel)
   - Dueling Dance, Dueling Parry, Twin Parry & Twin Defense now share the Raise a Shield animation. (@Aziareel)
-  - Cornucopia, Crushing Ground, Guidance, Heal Animal, Lose the Path, Mushroom Patch, Needle Darts, Tempest Surge, Wildfire, Darkvision, Grease, Harmonize Self, Revealing Light, See the Unseen, Combustion, Holy Light, Magnetic Acceleration, Vision of Death, Howling Blizzard, Disintegrate, Spirit Blast. (@Aziareel)
+  - Cornucopia, Crushing Ground, Guidance, Heal Animal, Lose the Path, Mushroom Patch, Needle Darts, Tempest Surge, Wildfire, Darkvision, Grease, Harmonize Self, Revealing Light, See the Unseen, Combustion, Holy Light, Magnetic Acceleration, Vision of Death, Howling Blizzard (+ Oscillating Wave), Disintegrate, Spirit Blast. (@Aziareel)
+  - Faerie Dust, Figment, Imaginary Weapon, Lay on Hands, Blazing Bolt, Blood Vendetta, Bloodspray Curse, Cleanse Affliction, Clear Mind, Sound Body, Darkness, False Vitality, Floating Flame, Heat Metal (+ Oscillating Wave), Paranoia, Translate, Water Breathing, Worm's Repast, Earthbind, Heroism, Cinder Swarm, Ymeri'S Mark, Breath of Life, Flammable Fumes, Toxic Cloud, Flame Vortex (+ Oscillating Wave)
   - Persistent Damage (On Apply Damage Effects Only) (@ChasarooniZ)
   - Creature Abilities; Urevian - Diabolic Quill (@ChasarooniZ)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](<https://semver.org/spec/v2.0.
 
 - Polish translation (thank you @Lioheart!)
 - **New Animations**
+  - Treat Wounds/Battle Medicine, Dirty Trick, Grapple, Trip. (@Aziareel)
+  - Champion's Resistence, Devise a Stratagem, Strategic Strike, Surgical Shock, Cyclonic Ascent, Sneak Attack, Exploit Vulnerability (using  PF2e Exploit Vulnerability)
   - Dueling Dance, Dueling Parry, Twin Parry & Twin Defense now share the Raise a Shield animation. (@Aziareel)
   - Cornucopia, Crushing Ground, Guidance, Heal Animal, Lose the Path, Mushroom Patch, Needle Darts, Tempest Surge, Wildfire, Darkvision, Grease, Harmonize Self, Revealing Light, See the Unseen, Combustion, Holy Light, Magnetic Acceleration, Vision of Death, Howling Blizzard, Disintegrate, Spirit Blast. (@Aziareel)
   - Persistent Damage (On Apply Damage Effects Only) (@ChasarooniZ)
@@ -22,6 +24,7 @@ and this project adheres to [Semantic Versioning](<https://semver.org/spec/v2.0.
 ### Fixed
 
 - Vitality Lash should now work again
+- Shield (Cantrip) should now work again(?)
 
 ## [0.9.1] - 2024-09-12
 

--- a/animations/actions/battle-medicine.json
+++ b/animations/actions/battle-medicine.json
@@ -1,0 +1,3 @@
+{
+	"action:battle-medicine": "action:treat-wounds"
+}

--- a/animations/actions/dirty-trick.json
+++ b/animations/actions/dirty-trick.json
@@ -1,0 +1,3 @@
+{
+	"action:dirty-trick": "action:surgical-shock"
+}

--- a/animations/actions/grapple.json
+++ b/animations/actions/grapple.json
@@ -1,0 +1,3 @@
+{
+	"action:grapple": "action:shove"
+}

--- a/animations/actions/treat-wounds.json
+++ b/animations/actions/treat-wounds.json
@@ -1,0 +1,52 @@
+{
+	"action:treat-wounds": [
+		{
+			"trigger": "skill-check",
+			"preset": "onToken",
+			"file": "jb2a.healing_generic.400px.green",
+			"options": {
+				"scaleToObject": 1.5,
+				"preset": {
+					"location": "target"
+				}
+			},
+			"predicate": [
+				{
+					"not": "check:outcome:failure"
+				}
+			],
+			"contents": [
+				{
+					"default": true
+				},
+				{
+					"predicate": [
+						"check:outcome:critical-failure"
+					],
+					"contents": [
+						{
+							"predicate": [
+								"jb2a:patreon"
+							],
+							"file": "jb2a.liquid.splash.red"
+						},
+						{
+							"predicate": [
+								"jb2a:free"
+							],
+							"file": "jb2a.liquid.splash.blue",
+							"options": {
+								"filter": {
+									"type": "ColorMatrix",
+									"options": {
+										"hue": 145
+									}
+								}
+							}
+						}
+					]
+				}
+			]
+		}
+	]
+}

--- a/animations/actions/trip.json
+++ b/animations/actions/trip.json
@@ -1,0 +1,3 @@
+{
+	"action:trip": "action:shove"
+}

--- a/animations/class/investigator/devise-a-stratagem.json
+++ b/animations/class/investigator/devise-a-stratagem.json
@@ -1,0 +1,3 @@
+{
+	"effect:devise-a-stratagem": "effect:sure-strike"
+}

--- a/animations/class/investigator/strategic-strike.json
+++ b/animations/class/investigator/strategic-strike.json
@@ -1,0 +1,25 @@
+{
+	"check:substitution:devise-a-stratagem": [
+		{
+			"trigger": "damage-roll",
+			"preset": "onToken",
+			"file": "jb2a.sneak_attack.dark_green",
+			"options": {
+				"delay": 1500,
+				"preset": {
+					"location": "target"
+				},
+				"scaleToObject": {
+					"value": 1.5,
+					"considerTokenScale": true
+				},
+				"filter": {
+					"type": "ColorMatrix",
+					"options": {
+						"hue": -60
+					}
+				}
+			}
+		}
+	]
+}

--- a/animations/class/investigator/surgical-shock.json
+++ b/animations/class/investigator/surgical-shock.json
@@ -1,0 +1,27 @@
+{
+	"action:surgical-shock": [
+		{
+			"trigger": "skill-check",
+			"preset": "melee",
+			"predicate": [
+				{
+					"not": "check:outcome:critical-failure"
+				}
+			],
+			"contents": [
+				{
+					"predicate": [
+						"jb2a:free"
+					],
+					"file": "jb2a.template_line_piercing.generic.01.orange"
+				},
+				{
+					"predicate": [
+						"jb2a:patreon"
+					],
+					"file": "jb2a.melee_generic.piercing.two_handed"
+				}
+			]
+		}
+	]
+}

--- a/animations/class/rogue/sneak-attack.json
+++ b/animations/class/rogue/sneak-attack.json
@@ -1,0 +1,10 @@
+{
+	"feature:sneak-attack": [
+		{
+			"reference": "check:substitution:devise-a-stratagem",
+			"predicate": [
+				"target:condition:off-guard"
+			]
+		}
+	]
+}

--- a/animations/class/thaumaturge/exploit-vulnerability.json
+++ b/animations/class/thaumaturge/exploit-vulnerability.json
@@ -1,0 +1,4 @@
+{
+	"effect:exploit-personal-antithesis": "effect:sure-strike",
+	"effect:exploit-mortal-weakness": "effect:sure-strike"
+}

--- a/animations/effects/champions-resistence.json
+++ b/animations/effects/champions-resistence.json
@@ -1,0 +1,3 @@
+{
+	"effect:champions-resistance": "effect:shield"
+}

--- a/animations/effects/cyclonic-ascent.json
+++ b/animations/effects/cyclonic-ascent.json
@@ -1,0 +1,3 @@
+{
+	"effect:cyclonic-ascent": "effect:warp-step"
+}

--- a/animations/items/healers-gloves.json
+++ b/animations/items/healers-gloves.json
@@ -1,0 +1,4 @@
+{
+	"item:slug:healers-gloves": "item:slug:heal",
+	"item:slug:healers-gloves-greater": "item:slug:healers-gloves"
+}

--- a/animations/spells/1st/athletic-rush.json
+++ b/animations/spells/1st/athletic-rush.json
@@ -1,0 +1,3 @@
+{
+	"effect:athletic-rush": "effect:warp-step"
+}

--- a/animations/spells/1st/breathe-fire.json
+++ b/animations/spells/1st/breathe-fire.json
@@ -3,43 +3,74 @@
 		{
 			"trigger": "place-template",
 			"preset": "template",
-			"file": "jb2a.burning_hands.01.orange",
 			"contents": [
 				{
 					"predicate": [
 						{
-							"gte": [
-								"settings:quality",
-								1
+							"not": "conservation-of-energy:cold"
+						}
+					],
+					"file": "jb2a.burning_hands.01.orange",
+					"contents": [
+						{
+							"file": "jb2a.burning_hands.01.orange"
+						},
+						{
+							"predicate": [
+								{
+									"gte": [
+										"settings:quality",
+										2
+									]
+								}
+							],
+							"contents": [
+								{
+									"options": {
+										"rotate": -20
+									}
+								},
+								{
+									"options": {
+										"rotate": 20
+									}
+								}
 							]
 						}
 					]
 				},
 				{
 					"predicate": [
+						"conservation-of-energy:cold"
+					],
+					"file": "jb2a.cone_of_cold.blue",
+					"contents": [
 						{
-							"gte": [
-								"settings:quality",
-								2
+							"file": "jb2a.cone_of_cold.blue"
+						},
+						{
+							"predicate": [
+								{
+									"gte": [
+										"settings:quality",
+										2
+									]
+								}
+							],
+							"contents": [
+								{
+									"options": {
+										"rotate": -20
+									}
+								},
+								{
+									"options": {
+										"rotate": 20
+									}
+								}
 							]
 						}
-					],
-					"options": {
-						"rotate": -20
-					}
-				},
-				{
-					"predicate": [
-						{
-							"gte": [
-								"settings:quality",
-								2
-							]
-						}
-					],
-					"options": {
-						"rotate": 20
-					}
+					]
 				}
 			]
 		}

--- a/animations/spells/1st/faerie-dust.json
+++ b/animations/spells/1st/faerie-dust.json
@@ -1,0 +1,3 @@
+{
+	"origin:item:slug:faerie-dust": "origin:item:slug:revealing-light"
+}

--- a/animations/spells/1st/figment.json
+++ b/animations/spells/1st/figment.json
@@ -1,0 +1,25 @@
+{
+	"effect:figment": [
+		{
+			"trigger": "effect",
+			"preset": "onToken",
+			"options": {
+				"scaleToObject": 1.5
+			},
+			"contents": [
+				{
+					"predicate": [
+						"jb2a:free"
+					],
+					"file": "jb2a.eyes.01.dark_green.many"
+				},
+				{
+					"predicate": [
+						"jb2a:patreon"
+					],
+					"file": "jb2a.eyes.01.dark_yellow.many"
+				}
+			]
+		}
+	]
+}

--- a/animations/spells/1st/imaginary-weapon.json
+++ b/animations/spells/1st/imaginary-weapon.json
@@ -1,0 +1,9 @@
+{
+	"item:slug:imaginary-weapon": [
+		{
+			"trigger": "attack-roll",
+			"preset": "melee",
+			"file": "jb2a.melee_attack.02.trail.01.blueyellow"
+		}
+	]
+}

--- a/animations/spells/1st/lay-on-hands.json
+++ b/animations/spells/1st/lay-on-hands.json
@@ -1,0 +1,15 @@
+{
+	"item:slug:lay-on-hands": [
+		{
+			"trigger": "damage-taken",
+			"preset": "onToken",
+			"file": "jb2a.cure_wounds.400px.blue",
+			"options": {
+				"scaleToObject": 1.5,
+				"preset": {
+					"location": "target"
+				}
+			}
+		}
+	]
+}

--- a/animations/spells/1st/sure-strike.json
+++ b/animations/spells/1st/sure-strike.json
@@ -1,0 +1,28 @@
+{
+	"effect:sure-strike": [
+		{
+			"trigger": [
+				"effect"
+			],
+			"preset": "onToken",
+			"file": "jb2a.glint.yellow.few.2",
+			"contents": [
+				{
+					"default": true
+				},
+				{
+					"predicate": [
+						"settings:persistent"
+					],
+					"options": {
+						"persist": {
+							"value": true,
+							"persistTokenPrototype": true
+						},
+						"tieToDocuments": true
+					}
+				}
+			]
+		}
+	]
+}

--- a/animations/spells/2nd/blazing-bolt.json
+++ b/animations/spells/2nd/blazing-bolt.json
@@ -1,0 +1,9 @@
+{
+	"item:slug:blazing-bolt": [
+		{
+			"trigger": "attack-roll",
+			"preset": "ranged",
+			"file": "jb2a.scorching_ray.01.orange"
+		}
+	]
+}

--- a/animations/spells/2nd/blood-vendetta.json
+++ b/animations/spells/2nd/blood-vendetta.json
@@ -1,0 +1,3 @@
+{
+	"item:slug:blood-vendetta": "item:slug:bloodspray-curse"
+}

--- a/animations/spells/2nd/cleanse-affliction.json
+++ b/animations/spells/2nd/cleanse-affliction.json
@@ -1,0 +1,15 @@
+{
+	"spell:slug:cleanse-affliction": [
+		{
+			"trigger": "action",
+			"preset": "onToken",
+			"file": "jb2a.energy_strands.in.green.01.2",
+			"options": {
+				"scaleToObject": 2,
+				"preset": {
+					"location": "target"
+				}
+			}
+		}
+	]
+}

--- a/animations/spells/2nd/clear-mind.json
+++ b/animations/spells/2nd/clear-mind.json
@@ -1,0 +1,3 @@
+{
+	"spell:slug:clear-mind": "spell:slug:cleanse-affliction"
+}

--- a/animations/spells/2nd/darkness.json
+++ b/animations/spells/2nd/darkness.json
@@ -1,0 +1,36 @@
+{
+	"origin:item:slug:darkness": [
+		{
+			"trigger": "place-template",
+			"preset": "template",
+			"file": "jb2a.darkness.black",
+			"options": {
+				"scaleToObject": 1.1
+			},
+			"contents": [
+				{
+					"predicate": [
+						{
+							"gte": [
+								"settings:quality",
+								1
+							]
+						}
+					]
+				},
+				{
+					"predicate": [
+						"settings:persistent"
+					],
+					"options": {
+						"persist": {
+							"value": true,
+							"persistTokenPrototype": true
+						},
+						"tieToDocuments": true
+					}
+				}
+			]
+		}
+	]
+}

--- a/animations/spells/2nd/false-vitality.json
+++ b/animations/spells/2nd/false-vitality.json
@@ -1,0 +1,18 @@
+{
+	"effect:false-vitality": [
+		{
+			"trigger": "effect",
+			"preset": "onToken",
+			"file": "jb2a.icon.heart.pink",
+			"options": {
+				"scaleToObject": 1.2,
+				"filter": {
+					"type": "ColorMatrix",
+					"options": {
+						"hue": -40
+					}
+				}
+			}
+		}
+	]
+}

--- a/animations/spells/2nd/floating-flame.json
+++ b/animations/spells/2nd/floating-flame.json
@@ -1,0 +1,11 @@
+{
+	"origin:item:slug:floating-flame": [
+		{
+			"reference": "origin:item:slug:wildfire",
+			"file": "jb2a.flaming_sphere.200px.orange.02",
+			"options": {
+				"scaleToObject": 1.5
+			}
+		}
+	]
+}

--- a/animations/spells/2nd/heat-metal.json
+++ b/animations/spells/2nd/heat-metal.json
@@ -1,0 +1,30 @@
+{
+	"item:slug:heat-metal": [
+		{
+			"trigger": "damage-roll",
+			"preset": "onToken",
+			"options": {
+				"preset": {
+					"location": "target"
+				},
+				"scaleToObject": 2
+			},
+			"contents": [
+				{
+					"predicate": [
+						{
+							"not": "conservation-of-energy:cold"
+						}
+					],
+					"file": "jb2a.flames.orange.03.2x2"
+				},
+				{
+					"predicate": [
+						"conservation-of-energy:cold"
+					],
+					"file": "jb2a.ice_spikes.radial.burst.white"
+				}
+			]
+		}
+	]
+}

--- a/animations/spells/2nd/paranoia.json
+++ b/animations/spells/2nd/paranoia.json
@@ -1,0 +1,28 @@
+{
+	"item:slug:paranoia": [
+		{
+			"trigger": "saving-throw",
+			"preset": "onToken",
+			"options": {
+				"preset": {
+					"location": "target"
+				},
+				"scaleToObject": 1.5
+			},
+			"contents": [
+				{
+					"predicate": [
+						"jb2a:free"
+					],
+					"file": "jb2a.eyes.01.dark_green.many"
+				},
+				{
+					"predicate": [
+						"jb2a:patreon"
+					],
+					"file": "jb2a.eyes.01.dark_yellow.many"
+				}
+			]
+		}
+	]
+}

--- a/animations/spells/2nd/powerful-inhalation.json
+++ b/animations/spells/2nd/powerful-inhalation.json
@@ -1,0 +1,12 @@
+{
+	"origin:item:slug:powerful-inhalation": [
+		{
+			"trigger": "place-template",
+			"preset": "template",
+			"file": "jb2a.explosion.04.blue",
+			"options": {
+				"scaleToObject": 1.5
+			}
+		}
+	]
+}

--- a/animations/spells/2nd/resist-energy.json
+++ b/animations/spells/2nd/resist-energy.json
@@ -1,0 +1,3 @@
+{
+	"effect:resist-energy": "effect:shield"
+}

--- a/animations/spells/2nd/sound-body.json
+++ b/animations/spells/2nd/sound-body.json
@@ -1,0 +1,3 @@
+{
+	"spell:slug:sound-body": "spell:slug:cleanse-affliction"
+}

--- a/animations/spells/2nd/translate.json
+++ b/animations/spells/2nd/translate.json
@@ -1,0 +1,15 @@
+{
+	"spell:slug:translate": [
+		{
+			"trigger": "action",
+			"preset": "onToken",
+			"file": "jb2a.magic_signs.rune.divination.intro.blue",
+			"options": {
+				"scaleToObject": 1.2,
+				"preset": {
+					"location": "target"
+				}
+			}
+		}
+	]
+}

--- a/animations/spells/2nd/water-breathing.json
+++ b/animations/spells/2nd/water-breathing.json
@@ -1,0 +1,15 @@
+{
+	"spell:slug:water-breathing": [
+		{
+			"trigger": "action",
+			"preset": "onToken",
+			"options": {
+				"scaleToObject": 1.5,
+				"preset": {
+					"location": "target"
+				}
+			},
+			"file": "jb2a.markers.bubble.02.complete.blue.0"
+		}
+	]
+}

--- a/animations/spells/2nd/worms-repast.json
+++ b/animations/spells/2nd/worms-repast.json
@@ -1,0 +1,25 @@
+{
+	"item:slug:worms-repast": [
+		{
+			"trigger": "saving-throw",
+			"preset": "onToken",
+			"options": {
+				"preset": {
+					"location": "target"
+				},
+				"scaleToObject": 1.5
+			},
+			"contents": [
+				{
+					"predicate": ["jb2a:free"],
+					"file": "jb2a.butterflies.many.orange"
+				},
+				{
+					"predicate": ["jb2a:patreon"],
+					"file": "jb2a.butterflies.complete.01.white"
+				}
+			]
+
+		}
+	]
+}

--- a/animations/spells/3rd/combustion.json
+++ b/animations/spells/3rd/combustion.json
@@ -3,19 +3,13 @@
 		{
 			"trigger": "damage-roll",
 			"preset": "onToken",
-			"file": "jb2a.campfire.03.02.loop.orange",
+			"file": "jb2a.flames.orange.03.2x2",
 			"options": {
 				"preset": {
-					"location": "target",
-					"atLocation": {
-						"offset": {
-							"y": -2.1
-						},
-						"gridUnits": true
-					}
+					"location": "target"
 				},
 				"scaleToObject": {
-					"value": 7,
+					"value": 1.8,
 					"considerTokenScale": true
 				}
 			}

--- a/animations/spells/3rd/earthbind.json
+++ b/animations/spells/3rd/earthbind.json
@@ -1,0 +1,24 @@
+{
+	"item:slug:earthbind": [
+		{
+			"trigger": "saving-throw",
+			"preset": "onToken",
+			"options": {
+				"scaleToObject": 1.5,
+				"preset": {
+					"location": "target"
+				}
+			},
+			"contents": [
+				{
+					"predicate": ["jb2a:free"],
+					"file": "jb2a.markers.chain.spectral_standard.complete.02.blue"
+				},
+				{
+					"predicate": ["jb2a:patreon"],
+					"file": "jb2a.markers.chain.diamond.loop.01.yellow"
+				}
+			]
+		}
+	]
+}

--- a/animations/spells/3rd/fireball.json
+++ b/animations/spells/3rd/fireball.json
@@ -5,26 +5,64 @@
 			"default": true,
 			"contents": [
 				{
-					"preset": "ranged",
+					"predicate": [
+						{
+							"not": "conservation-of-energy:cold"
+						}
+					],
 					"contents": [
 						{
-							"file": "jb2a.fire_bolt.orange",
-							"options": {
-								"waitUntilFinished": -1000
-							}
+							"preset": "ranged",
+							"contents": [
+								{
+									"file": "jb2a.fire_bolt.orange",
+									"options": {
+										"waitUntilFinished": -1000
+									}
+								}
+							]
+						},
+						{
+							"preset": "template",
+							"contents": [
+								{
+									"file": "jb2a.fireball.explosion.orange",
+									"options": {
+										"scaleToObject": {
+											"value": 1.5
+										}
+									}
+								}
+							]
 						}
 					]
 				},
 				{
-					"preset": "template",
+					"predicate": ["conservation-of-energy:cold"],
 					"contents": [
 						{
-							"file": "jb2a.fireball.explosion.orange",
-							"options": {
-								"scaleToObject": {
-									"value": 1.5
+							"preset": "ranged",
+							"contents": [
+								{
+									"file": "jb2a.spell_projectile.ice_shard.blue",
+									"options": {
+										"waitUntilFinished": -1500
+									}
 								}
-							}
+							]
+						},
+						{
+							"preset": "template",
+							"contents": [
+								{
+									"file": "jb2a.ice_spikes.radial.burst.white",
+									"options": {
+										"scaleToObject": {
+											"value": 1.5
+										}
+									}
+								}
+							]
 						}
 					]
 				}

--- a/animations/spells/3rd/heroism.json
+++ b/animations/spells/3rd/heroism.json
@@ -1,0 +1,3 @@
+{
+	"effect:heroism": "effect:slug:aura-courageous-anthem"
+}

--- a/animations/spells/4th/bloodspray-curse.json
+++ b/animations/spells/4th/bloodspray-curse.json
@@ -1,0 +1,39 @@
+{
+	"item:slug:bloodspray-curse": [
+		{
+			"trigger": "saving-throw",
+			"preset": "onToken",
+			"options": {
+				"sound": {
+					"file": "graphics-sfx.sword.melee.slice"
+				},
+				"preset": {
+					"location": "target"
+				},
+				"scaleToObject": 1.5
+			},
+			"contents": [
+				{
+					"predicate": [
+						"jb2a:patreon"
+					],
+					"file": "jb2a.liquid.splash.red"
+				},
+				{
+					"predicate": [
+						"jb2a:free"
+					],
+					"file": "jb2a.liquid.splash.blue",
+					"options": {
+						"filter": {
+							"type": "ColorMatrix",
+							"options": {
+								"hue": 145
+							}
+						}
+					}
+				}
+			]
+		}
+	]
+}

--- a/animations/spells/4th/cinder-swarm.json
+++ b/animations/spells/4th/cinder-swarm.json
@@ -1,0 +1,29 @@
+{
+	"origin:item:slug:cinder-swarm": [
+		{
+			"trigger": "place-template",
+			"preset": "template",
+			"file": "jb2a.fire_ring.500px.red",
+			"options": {
+				"scaleToObject": 1
+			},
+			"contents": [
+				{
+					"default": true
+				},
+				{
+					"predicate": [
+						"settings:persistent"
+					],
+					"options": {
+						"persist": {
+							"value": true,
+							"persistTokenPrototype": true
+						},
+						"tieToDocuments": true
+					}
+				}
+			]
+		}
+	]
+}

--- a/animations/spells/4th/fire-shield.json
+++ b/animations/spells/4th/fire-shield.json
@@ -1,27 +1,9 @@
 {
-	"effect:shield": [
-		{
-			"trigger": "effect",
-			"preset": "ranged",
-			"file": "jb2a.bullet.03.blue",
-			"predicate": [
-				{
-					"gte": [
-						"settings:quality",
-						1
-					]
-				},
-				"origin-exists"
-			],
-			"options": {
-				"mirrorX": true,
-				"waitUntilFinished": -1000
-			}
-		},
+	"effect:fire-shield": [
 		{
 			"preset": "onToken",
 			"trigger": "effect",
-			"file": "jb2a.shield.01.complete.01.blue",
+			"file": "jb2a.shield_themed.below.fire.01.orange",
 			"predicate": [
 				{
 					"gte": [
@@ -36,7 +18,7 @@
 					"considerTokenScale": true
 				},
 				"sound": {
-					"file": "graphics-sfx.magic.buff.generic.03"
+					"file": "graphics-sfx.magic.fire.armor"
 				}
 			},
 			"contents": [
@@ -53,11 +35,7 @@
 					}
 				},
 				{
-					"default": true,
-					"trigger": [
-						"effect",
-						"start-turn"
-					]
+					"default": true
 				}
 			]
 		}

--- a/animations/spells/4th/ymeris-mark.json
+++ b/animations/spells/4th/ymeris-mark.json
@@ -1,0 +1,28 @@
+{
+	"item:slug:ymeris-mark": [
+		{
+			"trigger": "damage-roll",
+			"preset": "onToken",
+			"options": {
+				"preset": {
+					"location": "target"
+				}
+			},
+			"contents": [
+				{
+					"file": "jb2a.magic_signs.rune.transmutation.intro.yellow",
+					"options": {
+						"waitUntilFinished": 250,
+						"scaleToObject": 1.2
+					}
+				},
+				{
+					"file": "jb2a.explosion.01.orange",
+					"options": {
+						"scaleToObject": 7
+					}
+				}
+			]
+		}
+	]
+}

--- a/animations/spells/5th/breath-of-life.json
+++ b/animations/spells/5th/breath-of-life.json
@@ -1,0 +1,3 @@
+{
+	"item:slug:breath-of-life": "item:slug:heal"
+}

--- a/animations/spells/5th/flammable-fumes.json
+++ b/animations/spells/5th/flammable-fumes.json
@@ -1,0 +1,37 @@
+{
+	"origin:item:slug:flammable-fumes": [
+		{
+			"trigger": "place-template",
+			"preset": "template",
+			"file": "jb2a.wind_lines.01.01.white",
+			"options": {
+				"scaleToObject": 1,
+				"rotate": 90
+			},
+			"contents": [
+				{
+					"predicate": [
+						{
+							"gte": [
+								"settings:quality",
+								1
+							]
+						}
+					]
+				},
+				{
+					"predicate": [
+						"settings:persistent"
+					],
+					"options": {
+						"persist": {
+							"value": true,
+							"persistTokenPrototype": true
+						},
+						"tieToDocuments": true
+					}
+				}
+			]
+		}
+	]
+}

--- a/animations/spells/5th/howling-blizzard.json
+++ b/animations/spells/5th/howling-blizzard.json
@@ -3,59 +3,103 @@
 		{
 			"trigger": "place-template",
 			"preset": "template",
-			"file": "jb2a.cone_of_cold.blue",
-			"predicate": [
-				"origin:item:area:type:cone"
-			],
+			"predicate": ["origin:item:area:type:cone"],
 			"contents": [
 				{
 					"predicate": [
 						{
-							"gte": [
-								"settings:quality",
-								1
+							"not": "conservation-of-energy:fire"
+						}
+					],
+					"file": "jb2a.cone_of_cold.blue",
+					"contents": [
+						{
+							"file": "jb2a.cone_of_cold.blue"
+						},
+						{
+							"predicate": [
+								{
+									"gte": [
+										"settings:quality",
+										2
+									]
+								}
+							],
+							"contents": [
+								{
+									"options": {
+										"rotate": -30
+									}
+								},
+								{
+									"options": {
+										"rotate": 30
+									}
+								}
 							]
 						}
 					]
 				},
 				{
-					"predicate": [
+					"predicate": ["conservation-of-energy:fire"],
+					"file": "jb2a.burning_hands.01.orange",
+					"contents": [
 						{
-							"gte": [
-								"settings:quality",
-								2
+							"file": "jb2a.burning_hands.01.orange"
+						},
+						{
+							"predicate": [
+								{
+									"gte": [
+										"settings:quality",
+										2
+									]
+								}
+							],
+							"contents": [
+								{
+									"options": {
+										"rotate": -30
+									}
+								},
+								{
+									"options": {
+										"rotate": 30
+									}
+								}
 							]
 						}
-					],
-					"options": {
-						"rotate": -30
-					}
-				},
-				{
-					"predicate": [
-						{
-							"gte": [
-								"settings:quality",
-								2
-							]
-						}
-					],
-					"options": {
-						"rotate": 30
-					}
+					]
 				}
 			]
 		},
 		{
 			"trigger": "place-template",
 			"preset": "template",
-			"file": "jb2a.sleet_storm.blue",
 			"predicate": [
 				"origin:item:area:type:burst"
 			],
-			"options": {
-				"scaleToObject": 1
-			}
+			"contents": [
+				{
+					"predicate": [
+						{
+							"not": "conservation-of-energy:fire"
+						}
+
+					],
+					"file": "jb2a.sleet_storm.blue",
+					"options": {
+						"scaleToObject": 1
+					}
+				},
+				{
+					"predicate": ["conservation-of-energy:fire"],
+					"file": "jb2a.fireball.explosion.orange",
+					"options": {
+						"scaleToObject": 1.5
+					}
+				}
+			]
 		}
 	],
 	"item:slug:howling-blizzard": [

--- a/animations/spells/5th/toxic-cloud.json
+++ b/animations/spells/5th/toxic-cloud.json
@@ -1,0 +1,36 @@
+{
+	"origin:item:slug:toxic-cloud": [
+		{
+			"trigger": "place-template",
+			"preset": "template",
+			"file": "jb2a.darkness.green",
+			"options": {
+				"scaleToObject": 1.1
+			},
+			"contents": [
+				{
+					"predicate": [
+						{
+							"gte": [
+								"settings:quality",
+								1
+							]
+						}
+					]
+				},
+				{
+					"predicate": [
+						"settings:persistent"
+					],
+					"options": {
+						"persist": {
+							"value": true,
+							"persistTokenPrototype": true
+						},
+						"tieToDocuments": true
+					}
+				}
+			]
+		}
+	]
+}

--- a/animations/spells/6th/flame-vortex.json
+++ b/animations/spells/6th/flame-vortex.json
@@ -1,0 +1,135 @@
+{
+	"origin:item:slug:flame-vortex": [
+		{
+			"trigger": "place-template",
+			"preset": "template",
+			"options": {
+				"scaleToObject": 1.5
+			},
+			"contents": [
+				{
+					"predicate": [
+						"jb2a:free"
+					],
+					"contents": [
+						{
+							"default": true,
+							"file": "jb2a.template_circle.vortex.intro.blue",
+							"options": {
+								"filter": {
+									"type": "ColorMatrix",
+									"options": {
+										"saturate": 0.8,
+										"hue": -160
+									}
+								}
+							},
+							"contents": [
+								{
+									"default": true
+								},
+								{
+									"predicate": [
+										"settings:persistent"
+									],
+									"options": {
+										"persist": {
+											"value": true,
+											"persistTokenPrototype": true
+										},
+										"tieToDocuments": true,
+										"filter": {
+											"type": "ColorMatrix",
+											"options": {
+												"saturate": 0.8,
+												"hue": -160
+											}
+										}
+									},
+									"file": "jb2a.template_circle.vortex.loop.blue"
+								}
+							]
+						},
+						{
+							"predicate": [
+								"conservation-of-energy:cold"
+							],
+							"file": "jb2a.template_circle.vortex.intro.blue",
+							"contents": [
+								{
+									"default": true
+								},
+								{
+									"predicate": [
+										"settings:persistent"
+									],
+									"options": {
+										"persist": {
+											"value": true,
+											"persistTokenPrototype": true
+										},
+										"tieToDocuments": true
+									},
+									"file": "jb2a.template_circle.vortex.loop.blue"
+								}
+							]
+						}
+					]
+				},
+				{
+					"predicate": [
+						"jb2a:patreon"
+					],
+					"contents": [
+						{
+							"default": true,
+							"file": "jb2a.template_circle.vortex.intro.orange",
+							"contents": [
+								{
+									"default": true
+								},
+								{
+									"predicate": [
+										"settings:persistent"
+									],
+									"options": {
+										"persist": {
+											"value": true,
+											"persistTokenPrototype": true
+										},
+										"tieToDocuments": true
+									},
+									"file": "jb2a.template_circle.vortex.loop.orange"
+								}
+							]
+						},
+						{
+							"predicate": [
+								"conservation-of-energy:cold"
+							],
+							"file": "jb2a.template_circle.vortex.intro.blue",
+							"contents": [
+								{
+									"default": true
+								},
+								{
+									"predicate": [
+										"settings:persistent"
+									],
+									"options": {
+										"persist": {
+											"value": true,
+											"persistTokenPrototype": true
+										},
+										"tieToDocuments": true
+									},
+									"file": "jb2a.template_circle.vortex.loop.blue"
+								}
+							]
+						}
+					]
+				}
+			]
+		}
+	]
+}

--- a/animations/weapons/group/spear.json
+++ b/animations/weapons/group/spear.json
@@ -32,6 +32,39 @@
 					}
 				}
 			]
+		},
+		{
+			"predicate": [
+				"jb2a:free"
+			],
+			"contents": [
+				{
+					"trigger": "attack-roll",
+					"preset": "ranged",
+					"file": "jb2a.bolt.physical.orange",
+					"predicate": [
+						"thrown"
+					],
+					"options": {
+						"preset": {
+							"stretchTo": {
+								"randomOffset": 0.5
+							}
+						}
+					}
+				},
+				{
+					"trigger": "attack-roll",
+					"preset": "melee",
+					"file": "jb2a.spear.melee.01.white",
+					"predicate": [
+						"melee"
+					],
+					"options": {
+						"scaleToObject": 5
+					}
+				}
+			]
 		}
 	]
 }


### PR DESCRIPTION
See Changes.

Some of them are more placeholders and reference existing animations.

Special Commentary for individual entries:
- Devise a stratagem: Might be replaced in the future with a glowing lightbulb symbol
- Powerful Inhalation: A way to reverse animations would provide benefits (But I assume that would be a Sequencer thing, and they do not seem to have it)
- Fire Shield: It seems that there is no roll option regarding Oscillating Wave
- Cinder Swarm: It seems there is no roll option to distinguish Fire Ants/Fireflies

Questions:
- Is it possible to use roll options like: "item:rank:X" so that the X-Value can be used directly for values (without using predicates). For example using the spell rank of Needle Darts to set the number of repetitions for the animation.
- Some roll options, like resist energy, seem to contain escaped characters (for the resistance selection). How can I use them within the animation .json files? Example: "effect:rule-selection:resist-energy-type:\\"cold\\""
- Is it possible to offset animations dependig on the token size. Static offsets do not really work with Large/Huge/Gargantuan tokens.
- Some effects have an expiration. Is it possible to listen to/access the expiration property?

Thank you,
I will edit requested changes later today.
