### PR TITLE
Update schema for new presets + migrate to own directory

### DIFF
--- a/scripts/buildJSONSchema.ts
+++ b/scripts/buildJSONSchema.ts
@@ -3,24 +3,53 @@
 
 import fs from 'node:fs/promises';
 import p from 'picocolors';
-import { getJSONSchema } from 'src/storage/animationsSchema';
+import { animations, tokenImages } from 'src/schema';
+import { zodToJsonSchema, type Options as zodToJsonSchemaOptions } from 'zod-to-json-schema';
 import { Log } from './helpers';
 
+/**
+ * Converts a Zod schema into a JSON schema.
+ *
+ * @param schemaName The type of the Zod schema being emitted (either `animations` or `tokenImages`).
+ * @returns The JSON-schema representation for that Zod schema.
+ */
+export function getJSONSchema(schemaName: 'animations' | 'tokenImages') {
+	const options: Partial<zodToJsonSchemaOptions> = {
+		markdownDescription: true,
+		removeAdditionalStrategy: 'strict',
+		applyRegexFlags: true,
+		// errorMessages: true, // Would like this enabled, but it seems to cause problems in VSCode
+	};
+
+	if (schemaName === 'animations') return zodToJsonSchema(animations, options);
+	if (schemaName === 'tokenImages') return zodToJsonSchema(tokenImages, options);
+	throw new Error('Unknown schema name');
+}
+
+/**
+ * The directory to which the JSON schema should be written when building manually using `npm run build:schema`.
+ */
 const OUTPUT_DIRECTORY = './dist';
 
-fs.stat(OUTPUT_DIRECTORY).catch(() => {
-	Log.warning(`${OUTPUT_DIRECTORY} does not exist. Creating it...`);
-	fs.mkdir(OUTPUT_DIRECTORY);
-}).finally(() => {
-	fs.writeFile(`${OUTPUT_DIRECTORY}/animations-schema.json`, JSON.stringify(getJSONSchema('animations')), {
-		encoding: 'utf8',
-	}).then(() => Log.info(p.green('Generated animations JSON schema.'))).catch(() => Log.error(p.red('Failed to generate animations JSON schema.')));
-
-	fs.writeFile(
-		`${OUTPUT_DIRECTORY}/token-images-schema.json`,
-		JSON.stringify(getJSONSchema('tokenImages')),
-		{
+fs.stat(OUTPUT_DIRECTORY)
+	.catch(() => {
+		Log.warning(`${OUTPUT_DIRECTORY} does not exist. Creating it...`);
+		fs.mkdir(OUTPUT_DIRECTORY);
+	})
+	.finally(() => {
+		fs.writeFile(`${OUTPUT_DIRECTORY}/animations-schema.json`, JSON.stringify(getJSONSchema('animations')), {
 			encoding: 'utf8',
-		},
-	).then(() => Log.info(p.green('Generated token-images JSON schema.'))).catch(() => Log.error(p.red('Failed to generate token-images JSON schema.')));
-});
+		})
+			.then(() => Log.info(p.green('Generated animations JSON schema.')))
+			.catch(() => Log.error(p.red('Failed to generate animations JSON schema.')));
+
+		fs.writeFile(
+			`${OUTPUT_DIRECTORY}/token-images-schema.json`,
+			JSON.stringify(getJSONSchema('tokenImages')),
+			{
+				encoding: 'utf8',
+			},
+		)
+			.then(() => Log.info(p.green('Generated token-images JSON schema.')))
+			.catch(() => Log.error(p.red('Failed to generate token-images JSON schema.')));
+	});

--- a/src/schema/helpers/atoms.ts
+++ b/src/schema/helpers/atoms.ts
@@ -1,0 +1,200 @@
+import { z } from 'zod';
+import { nonZero, uniqueItems } from './refinements';
+
+/**
+ * Zod schema for any possible value that can be encoded in JSON.
+ */
+export const JSONValue = z
+	.union([z.string(), z.number(), z.boolean(), z.object({}), z.null(), z.undefined()])
+	.describe('Any possible value that can be encoded in JSON.');
+
+/**
+ * Zod schema for a Foundry item's slug for the pf2e system.
+ */
+export const slug = z
+	.string()
+	.regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, 'String must be a valid slug.')
+	.describe('A Foundry item\'s slug for the pf2e system.');
+
+/**
+ * Zod schema for a roll option in the pf2e system.
+ */
+export const rollOption = z
+	.string()
+	.regex(
+		/^[a-z0-9]+(?:-[a-z0-9]+)*(?::[a-z0-9]+(?:-[a-z0-9]+)*)*(?::-?\d+)?$/,
+		'String must be a valid roll option.',
+	)
+	.describe('A roll option in the pf2e system.');
+
+/**
+ * Zod schema for a hexadecimal colour, represented as a string (leading hash).
+ */
+export const hexColour = z
+	.string()
+	.regex(/^#[0-9a-f]{3}(?:[0-9a-f]{3})?$/i, 'String must be a valid hexadecimal colour-code.')
+	.describe('A hexadecimal colour, represented as a string (leading hash).');
+
+/**
+ * Zod schema for an angle in degrees. The value is normalised from -180° < x <= 180°, with a value of 0° being disallowed as the default.
+ */
+export const angle = z
+	.number()
+	.gt(-180)
+	.lte(180)
+	.refine(...nonZero)
+	.describe(
+		'An angle in degrees. The value is normalised from -180° < x <= 180°, with a value of 0° being disallowed as the default.',
+	);
+
+/**
+ * Zod schema for a filepath (cross-platform-safe) to a meaningful animation file (extension required).
+ */
+export const filePath = z
+	.string()
+	.regex(
+		/^\w[^":<>?\\|/]+(?:\/[^":<>?\\|/]+)+\.\w\w\w\w?$/,
+		'String must be a valid filepath. The following characters are unsafe for cross-platform filesystems: ":<>?\\|',
+	)
+	.describe('A filepath (cross-platform-safe) to a meaningful animation file (extension required).');
+
+/**
+ * Zod schema for a Sequencer database entry.
+ */
+export const sequencerDBEntry = z
+	.string()
+	.regex(/^\w[\w-]+(?:\.(?:[\w-]+|\{\w+(?:,[^{},]+)+\}))+$/, 'String must be a valid Sequencer database entry.')
+	.describe('A Sequencer database entry.');
+
+/**
+ * Zod schema for an easing function (c.f. easings.net).
+ */
+export const easing = z
+	.enum([
+		'easeInBack',
+		'easeInBounce',
+		'easeInCirc',
+		'easeInCubic',
+		'easeInElastic',
+		'easeInExpo',
+		'easeInOutBack',
+		'easeInOutBounce',
+		'easeInOutCirc',
+		'easeInOutCubic',
+		'easeInOutElastic',
+		'easeInOutExpo',
+		'easeInOutQuad',
+		'easeInOutQuart',
+		'easeInOutQuint',
+		'easeInOutSine',
+		'easeInQuad',
+		'easeInQuart',
+		'easeInQuint',
+		'easeInSine',
+		'easeOutBack',
+		'easeOutBounce',
+		'easeOutCirc',
+		'easeOutCubic',
+		'easeOutElastic',
+		'easeOutExpo',
+		'easeOutQuad',
+		'easeOutQuart',
+		'easeOutQuint',
+		'easeOutSine',
+	])
+	.describe('An easing function (c.f. easings.net).');
+
+/**
+ * A single predicate (recursive) for the pf2e system.
+ */
+export type Predicate =
+	| string
+	| { eq: [string, string | number] }
+	| { gt: [string, string | number] }
+	| { gte: [string, string | number] }
+	| { lt: [string, string | number] }
+	| { lte: [string, string | number] }
+	| { and: Predicate[] }
+	| { or: Predicate[] }
+	| { xor: Predicate[] }
+	| { not: Predicate }
+	| { nand: Predicate[] }
+	| { nor: Predicate[] }
+	| { if: Predicate; then: Predicate }
+	| { iff: Predicate[] };
+
+/**
+ * Zod schema for a single predicate (recursive) for the pf2e system.
+ */
+export const predicate: z.ZodType<Predicate> = z
+	.union([
+		rollOption,
+		z.object({ eq: z.tuple([rollOption, rollOption.or(z.number())]) }).strict(),
+		z.object({ gt: z.tuple([rollOption, rollOption.or(z.number())]) }).strict(),
+		z.object({ gte: z.tuple([rollOption, rollOption.or(z.number())]) }).strict(),
+		z.object({ lt: z.tuple([rollOption, rollOption.or(z.number())]) }).strict(),
+		z.object({ lte: z.tuple([rollOption, rollOption.or(z.number())]) }).strict(),
+		z
+			.object({
+				and: z.lazy(() =>
+					z
+						.array(predicate)
+						.min(1)
+						.refine(...uniqueItems),
+				),
+			})
+			.strict(),
+		z
+			.object({
+				or: z.lazy(() =>
+					z
+						.array(predicate)
+						.min(1)
+						.refine(...uniqueItems),
+				),
+			})
+			.strict(),
+		z
+			.object({
+				xor: z.lazy(() =>
+					z
+						.array(predicate)
+						.min(1)
+						.refine(...uniqueItems),
+				),
+			})
+			.strict(),
+		z.object({ not: z.lazy(() => predicate) }).strict(),
+		z
+			.object({
+				nand: z.lazy(() =>
+					z
+						.array(predicate)
+						.min(1)
+						.refine(...uniqueItems),
+				),
+			})
+			.strict(),
+		z
+			.object({
+				nor: z.lazy(() =>
+					z
+						.array(predicate)
+						.min(1)
+						.refine(...uniqueItems),
+				),
+			})
+			.strict(),
+		z.object({ if: z.lazy(() => predicate), then: z.lazy(() => predicate) }).strict(),
+		z
+			.object({
+				iff: z.lazy(() =>
+					z
+						.array(predicate)
+						.min(1)
+						.refine(...uniqueItems),
+				),
+			})
+			.strict(),
+	])
+	.describe('A single predicate (recursive) for the pf2e system.');

--- a/src/schema/helpers/refinements.ts
+++ b/src/schema/helpers/refinements.ts
@@ -1,0 +1,27 @@
+/**
+ * Zod refinement to ensure a numeric value isn't zero.
+ */
+export const nonZero: [(num: number) => boolean, string] = [
+	num => num !== 0,
+	'Number cannot be 0. If you want the value to be 0, simply leave the property undefined.',
+];
+
+/**
+ * Zod refinement to ensure an object has at least one property.
+ */
+export const nonEmpty: [(obj: object) => boolean, string] = [
+	(obj) => {
+		// eslint-disable-next-line no-unreachable-loop
+		for (const _key in obj) return true; // This is simply most performant ¯\_(ツ)_/¯
+		return false;
+	},
+	'Object must not be empty.',
+];
+
+/**
+ * Zod refinement to ensure an array has no duplicate elements (not perfect, but good enough).
+ */
+export const uniqueItems: [(arr: any[]) => boolean, string] = [
+	arr => new Set(arr.map(e => JSON.stringify(e))).size === arr.length,
+	'Items must be unique.',
+];

--- a/src/schema/helpers/structures.ts
+++ b/src/schema/helpers/structures.ts
@@ -1,0 +1,81 @@
+import { z } from 'zod';
+import { easing } from './atoms';
+import { nonEmpty, nonZero } from './refinements';
+
+/**
+ * Zod schema for a 2D vector.
+ */
+export const vector2 = z
+	.object({
+		x: z
+			.number()
+			.refine(...nonZero)
+			.optional(),
+		y: z
+			.number()
+			.refine(...nonZero)
+			.optional(),
+	})
+	.strict()
+	.refine(...nonEmpty)
+	.describe('A 2D vector.');
+
+/**
+ * Zod schema for an offset value, in pixels.
+ */
+const offsetValue = z
+	.number()
+	.refine(...nonZero)
+	.describe('An offset value, in pixels.');
+
+/**
+ * Zod schema for an offset range, in pixels, from which to randomly select a value.
+ */
+const offsetRange = z
+	.tuple([z.number(), z.number()])
+	.refine(arr => arr[0] !== arr[1], 'Offset range cannot be zero.')
+	.describe('An offset range, in pixels, from which to randomly select a value.');
+
+/**
+ * Zod schema for a 2D offset, accepting either single- or range-values for either axis.
+ */
+export const offset = z
+	.object({
+		x: offsetValue.or(offsetRange).optional(),
+		y: offsetValue.or(offsetRange).optional(),
+	})
+	.strict()
+	.refine(...nonEmpty)
+	.describe('A 2D offset, accepting either single- or range-values for either axis.');
+
+/**
+ * Zod schema for the base options of animation modifier's easing.
+ */
+export const easingOptions = z
+	.object({
+		ease: easing.optional(),
+		delay: z
+			.number()
+			.refine(...nonZero)
+			.optional()
+			.describe('The delay before the effect starts or ends, as appropriate, in milliseconds.'),
+	})
+	.strict()
+	.describe('The base options of animation modifier\'s easing.');
+
+/**
+ * Zod schema for a configuration to place an animation/sound at a particular location on the canvas, with an optional offset.
+ */
+export const atLocation = z
+	.object({
+		cacheLocation: z.literal(true).optional(),
+		offset: offset.optional(),
+		randomOffset: z.number().optional(),
+		gridUnits: z.literal(true).optional(),
+		local: z.literal(true).optional(),
+	})
+	.strict()
+	.refine(...nonEmpty)
+	.describe(
+		'A configuration to place an animation/sound at a particular location on the canvas, with an optional offset.',
+	);

--- a/src/schema/presets/sound.ts
+++ b/src/schema/presets/sound.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+import { predicate } from '../helpers/atoms';
+import { nonZero, uniqueItems } from '../helpers/refinements';
+import { atLocation } from '../helpers/structures';
+
+/**
+ * Zod schema for a sound effect (i.e. an effect applied to a sound).
+ */
+const soundEffect = z
+	.object({
+		type: z.string().min(1),
+		intensity: z.number().positive(),
+	})
+	.strict()
+	.describe('A sound effect (i.e. an effect applied to a sound).');
+
+/**
+ * Zod schema for the `sound` preset options.
+ */
+export const soundOptions = z
+	.object({
+		waitUntilFinished: z.number().optional(),
+		atLocation: atLocation.optional(),
+		radius: z.number().positive().optional(),
+		volume: z.number().positive().optional(),
+		duration: z.number().positive().optional(),
+		constrainedByWalls: z.literal(true).optional(),
+		predicate: z
+			.array(predicate)
+			.min(1)
+			.refine(...uniqueItems)
+			.optional(),
+		default: z.literal(true).optional(),
+		delay: z
+			.number()
+			.refine(...nonZero)
+			.optional(),
+		muffledEffect: soundEffect.optional(),
+		baseEffect: soundEffect.optional(),
+	})
+	.strict()
+	.describe('`sound` preset options.');
+
+/**
+ * `sound` preset options.
+ */
+export type SoundPresetOptions = z.infer<typeof soundOptions>;

--- a/src/schema/tokenImages.ts
+++ b/src/schema/tokenImages.ts
@@ -1,0 +1,99 @@
+import { z } from 'zod';
+import { easing, filePath, JSONValue, slug } from './helpers/atoms';
+import { nonEmpty, uniqueItems } from './helpers/refinements';
+
+/**
+ * Zod schema for a token's image data.
+ */
+const tokenImageData = z
+	.object({
+		name: z.string().min(1),
+		uuid: z.string().regex(/^[a-z0-9]+(?:\.[a-z0-9-]+)+$/i, 'Must be a valid UUID.'),
+		requires: z.string().min(1).optional(),
+		rules: z
+			.array(
+				z
+					.tuple([
+						slug,
+						filePath,
+						z.number().positive(),
+						filePath.optional(),
+						z.number().positive().optional(),
+					])
+					.or(
+						z
+							.object({
+								key: JSONValue.optional(),
+								label: JSONValue.optional(),
+								slug: JSONValue.optional(),
+								predicate: JSONValue.optional(),
+								priority: JSONValue.optional(),
+								ignored: JSONValue.optional(),
+								requiresInvestment: JSONValue.optional(),
+								requiresEquipped: JSONValue.optional(),
+								removeUponCreate: JSONValue.optional(),
+								value: filePath,
+								scale: z.number().optional(),
+								tint: z.string().optional(),
+								alpha: z.number().optional(),
+								animation: z
+									.object({
+										duration: z.number().positive().optional(),
+										transition: z.string().min(1).optional(),
+										easing: easing.optional(),
+										name: z.string().min(1).optional(),
+									})
+									.strict()
+									.refine(...nonEmpty),
+								ring: z
+									.object({
+										subject: z
+											.object({
+												texture: filePath,
+												scale: z.number().optional(),
+											})
+											.strict()
+											.refine(...nonEmpty),
+										colors: z
+											.object({
+												background: z.string().optional(),
+												ring: z.string().optional(),
+											})
+											.strict()
+											.refine(...nonEmpty)
+											.optional(),
+									})
+									.strict()
+									.refine(...nonEmpty)
+									.optional(),
+							})
+							.strict(),
+					),
+			)
+			.min(1)
+			.refine(...uniqueItems)
+			.optional(),
+	})
+	.strict()
+	.describe('A token\'s image data.');
+
+/**
+ * A token's image data.
+ */
+export type TokenImageData = z.infer<typeof tokenImageData>;
+
+/**
+ * Zod schema for an object containing the `_tokenImages` property of the merged animation JSON.
+ */
+export const tokenImages = z.object({
+	_tokenImages: z
+		.array(tokenImageData)
+		.min(1)
+		.refine(...uniqueItems)
+		.describe('An object containing the `_tokenImages` property of the merged animation JSON.'),
+});
+
+/**
+ * The `_tokenImages` property of the merged animation JSON.
+ */
+export type TokenImages = z.infer<typeof tokenImages>;

--- a/src/schema/triggers.ts
+++ b/src/schema/triggers.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+
+/**
+ * An array of all triggers that PF2e Graphics recognises.
+ */
+export const TRIGGERS = [
+	'attack-roll',
+	'damage-roll',
+	'place-template',
+	'action',
+	'toggle',
+	'effect',
+	'self-effect',
+	'start-turn',
+	'end-turn',
+	'damage-taken',
+	'saving-throw',
+	'check',
+	'skill-check',
+	'flat-check',
+	'initiative',
+	'perception-check',
+	'counteract-check',
+	'modifiers-matter',
+] as const;
+
+/**
+ * Zod schema for a trigger that PF2e Graphics recognises.
+ */
+export const triggers = z.enum(TRIGGERS).describe('A trigger that PF2e Graphics recognises.');
+
+/**
+ * A trigger that PF2e Graphics recognises.
+ */
+export type Trigger = z.infer<typeof triggers>;

--- a/src/storage/animationsSchema.ts
+++ b/src/storage/animationsSchema.ts
@@ -785,6 +785,7 @@ const referenceObject = z
 			.refine(...uniqueItems)
 			.optional(),
 		options: effectOptions.optional(),
+		macro: z.string().optional(),
 		reference: rollOption.optional(),
 	})
 	.strict();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,9 +12,9 @@ import { type Connect, defineConfig, type PluginOption, type ViteDevServer } fro
 import checker from 'vite-plugin-checker';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import moduleJSON from './module.json' with { type: 'json' };
+import { getJSONSchema } from './scripts/buildJSONSchema';
 import { type FileValidationFailure, Log, pluralise } from './scripts/helpers';
 import { testAndMergeAnimations } from './scripts/testAndMergeAnimations';
-import { getJSONSchema } from './src/storage/animationsSchema';
 
 const packagePath = `modules/${moduleJSON.id}`;
 


### PR DESCRIPTION
Just putting this here so you can monitor progress. Committed files are considered fully done, more or less.

As you can see, I'm trying to document as I go along. Hopefully makes things easier in the long-run! When everything's sorted on this end, I'll go through updating imports in other files.

There's a minor problem with the `z.discriminatedUnion()` idea to have the schema automatically select the correct `options` based on `preset` (i.e. so the JSON schema can provide hints despite the lack of `refine()`). In particular, you can't `.extend()` a discriminated union. This is troublesome, because we'd like to first define the 'shallow' schema, and then extend it recursively afterwards with `contents` (Zod requires a type annotation to avoid crying). I haven't tested any of this yet, but the workarounds I can think of right now include:
- Duplicate the recursive `contents` structure within each element of the discriminated union.
- Define a separate schema for each `preset` group. Set up each of these schemas to be recursive _for itself_ (i.e. no `preset`-switching inside `contents`). Next, define a top-level schema with no `preset` or `options`, and allow that to recursively contain a union of the aforementioned schemas.
- Fall back to simply making it all work with `.refine()` (RIP JSON-users).

First one is the simplest, but would result in a very hefty object that's quite hard to read and edit. Second one is most complex, but would remain mostly atomic if fine-tuning is needed (the restriction against `preset`-switching may also be desirable?). Third one is what we currently have; only one I can guarantee right now to actually work, but would indeed make writing JSON only a marginally smaller pain than it was without any schema at all.

~~This is as much notes for me as you 🥴~~